### PR TITLE
Fix trophy section resource fetch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 <div align="center">
 
-![trophy](https://github-profile-trophy.vercel.app/?username=dollspace-gay&theme=algolia&no-frame=true&no-bg=false&margin-w=4&column=4&row=2)
+![trophy](https://github-profile-trophy.vercel.app/?username=dollspace-gay&theme=algolia&no-frame=true&no-bg=true&margin-w=4)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 <div align="center">
 
-![trophy](https://github-profile-trophy.vercel.app/?username=dollspace-gay&theme=algolia&no-frame=true&no-bg=true&margin-w=4)
+[![trophy](https://github-profile-trophy.vercel.app/?username=dollspace-gay&theme=tokyonight&no-frame=true&no-bg=true)](https://github.com/ryo-ma/github-profile-trophy)
 
 </div>
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the README’s GitHub Trophies badge to a new URL with tokyonight theme, no-bg, and wraps it in a link.
> 
> - **README**:
>   - **GitHub Trophies**: Replace trophy image markdown with linked badge using `github-profile-trophy`.
>     - Switch theme from `algolia` to `tokyonight`.
>     - Update params: `no-frame=true`, `no-bg=true`.
>     - Wrap badge in link to `ryo-ma/github-profile-trophy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b4fed783c53c38edaea5064854bb95c05feb713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->